### PR TITLE
These aren't used and shouldn't be hardcoded

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -2,7 +2,5 @@
 #define CONFIG_H
 
 #define SDDM_CONFIG_FILE    "@SDDM_CONFIG_FILE@"
-const QString HALT_COMMAND = "/sbin/shutdown -h -P now";
-const QString REBOOT_COMMAND = "/sbin/shutdown -r now";
 
 #endif //CONFIG_H


### PR DESCRIPTION
when need these should be read from the config file.
ATM the code already do that, so no need to have these here.
